### PR TITLE
Incorrect css selector fix

### DIFF
--- a/gnome-professional-solid-40.1-dark/gtk-3.0/main-dark.css
+++ b/gnome-professional-solid-40.1-dark/gtk-3.0/main-dark.css
@@ -2467,7 +2467,7 @@ combobox:drop(active)
 	                  -1px    0px alpha(@text_shadow_color, 0.12);
   box-shadow: none;
 }
-//*(((((((((( Toolbars )))))))))) 
+/*(((((((((( Toolbars )))))))))) 
 */
 toolbar, .inline-toolbar, 
 searchbar > revealer > box, 


### PR DESCRIPTION
Removing a superfluous slash character preceding a css comment that provokes a GTK parsing error.