### PR TITLE
Context menu separator margin adjustment.

### DIFF
--- a/gnome-professional-solid-40.1-dark/gtk-3.0/main-dark.css
+++ b/gnome-professional-solid-40.1-dark/gtk-3.0/main-dark.css
@@ -8722,6 +8722,10 @@ viewswitcherbar actionbar > revealer > box
           padding-top: 8px;
           padding-bottom: 8px;
 }
+/* Mierzej's revision */
+window.background.csd.popup > menu > separator {
+  margin: 1px;
+}
 /* DO NOT CHANGE ANYTHNG DOWN THE LINE HERE*/
 
 @define-color color_100 shade(@color_accent,1.9);

--- a/gnome-professional-solid-40.1-dark/gtk-3.0/main-light.css
+++ b/gnome-professional-solid-40.1-dark/gtk-3.0/main-light.css
@@ -8710,6 +8710,10 @@ viewswitcherbar actionbar > revealer > box
           padding-top: 8px;
           padding-bottom: 8px;
 }
+/* Mierzej's revision */
+window.background.csd.popup > menu > separator {
+  margin: 1px;
+}
 /* DO NOT CHANGE ANYTHNG DOWN THE LINE HERE*/
 
 @define-color color_100 shade(@color_accent,1.9);


### PR DESCRIPTION
Correcting separator and popup border overlap for both: `main-dark.css` and `main-light.css`.